### PR TITLE
Use the full fqdn for argument types

### DIFF
--- a/src/main/kotlin/godot/entrygenerator/generator/function/JvmFunctionRegistrationGenerator.kt
+++ b/src/main/kotlin/godot/entrygenerator/generator/function/JvmFunctionRegistrationGenerator.kt
@@ -36,14 +36,14 @@ class JvmFunctionRegistrationGenerator : FunctionRegistrationGenerator() {
                 functionDescriptor.valueParameters.forEach { valueParameter ->
                     add(ktFunctionArgumentClassName)
                     add(valueParameter.type.toKtVariantType())
-                    add(valueParameter.type.getJetTypeFqName(false).substringAfterLast("."))
+                    add(valueParameter.type.getJetTypeFqName(false))
                     add(valueParameter.name.asString())
                 }
             }
 
             add(ktFunctionArgumentClassName)
             add(returnType.toKtVariantType())
-            add(returnType.getJetTypeFqName(false).substringAfterLast("."))
+            add(returnType.getJetTypeFqName(false))
         }
     }
 

--- a/src/main/kotlin/godot/entrygenerator/generator/property/JvmPropertyRegistrationGenerator.kt
+++ b/src/main/kotlin/godot/entrygenerator/generator/property/JvmPropertyRegistrationGenerator.kt
@@ -44,7 +44,7 @@ class JvmPropertyRegistrationGenerator : PropertyRegistrationGenerator() {
                 getGetterValueConverterReference(),
                 getSetterValueConverterReference(propertyDescriptor),
                 propertyDescriptor.type.toKtVariantType(),
-                propertyDescriptor.type.getJetTypeFqName(false).substringAfterLast("."),
+                propertyDescriptor.type.getJetTypeFqName(false),
                 PropertyTypeHintProvider.provide(propertyDescriptor, EntryGenerationType.JVM),
                 PropertyHintStringGeneratorProvider.provide(propertyDescriptor, bindingContext).getHintString()
             )

--- a/src/main/kotlin/godot/entrygenerator/generator/signal/JvmSignalRegistrationGenerator.kt
+++ b/src/main/kotlin/godot/entrygenerator/generator/signal/JvmSignalRegistrationGenerator.kt
@@ -58,7 +58,7 @@ class JvmSignalRegistrationGenerator : SignalRegistrationGenerator() {
             signalArguments.forEachIndexed { index, type ->
                 add(ClassName("godot.runtime", "KtFunctionArgument"))
                 add(type.toKtVariantType())
-                add(type.getJetTypeFqName(false).substringAfterLast("."))
+                add(type.getJetTypeFqName(false))
                 add(signalArgumentNamesAsLiteralStrings[index]) //out of bounds already checked
             }
         }.toTypedArray()


### PR DESCRIPTION
As discussed in https://github.com/utopia-rise/godot-jvm/pull/23 the full fqdn of arguments is required to identify if an argument is a "user type".

This PR fixes that. But this change might break lots things that I know nothing about since this is the first time I see this code base. Please point me in the right direction if this breaks something. Or if there is an entirely different approach that will solve this in a better way.