### PR TITLE
Seperate engine type registration and user types

### DIFF
--- a/src/main/kotlin/godot/entrygenerator/filebuilder/JvmEntryFileBuilder.kt
+++ b/src/main/kotlin/godot/entrygenerator/filebuilder/JvmEntryFileBuilder.kt
@@ -18,6 +18,11 @@ class JvmEntryFileBuilder(bindingContext: BindingContext): EntryFileBuilder(bind
             .receiver(ClassName("godot.runtime.Entry", "Context"))
             .addModifiers(KModifier.OVERRIDE)
 
+        val initEngineTypesFunSpec = FunSpec
+                .builder("initEngineTypes")
+                .receiver(ClassName("godot.runtime.Entry", "Context"))
+                .addModifiers(KModifier.OVERRIDE)
+
         val classRegistryControlFlow = initFunctionSpec
             .beginControlFlow("with(registry)·{") //START: with registry
 
@@ -25,11 +30,13 @@ class JvmEntryFileBuilder(bindingContext: BindingContext): EntryFileBuilder(bind
             .provideClassRegistrationProvider(EntryGenerationType.JVM)
             .registerClasses(classesWithMembers, classRegistryControlFlow, bindingContext)
 
-        classRegistryControlFlow.addStatement("%M()", MemberName("godot", "registerEngineTypes"))
+        initEngineTypesFunSpec.addStatement("%M()", MemberName("godot", "registerEngineTypes"))
+        initEngineTypesFunSpec.addStatement("%M()", MemberName("godot", "registerEngineTypeMethods"))
 
         classRegistryControlFlow.endControlFlow() //END: with registry
 
         entryClassSpec.addFunction(initFunctionSpec.build())
+        entryClassSpec.addFunction(initEngineTypesFunSpec.build())
         entryFileSpec.addType(entryClassSpec.build())
         return this
     }


### PR DESCRIPTION
This register engine types before user classes.
This also adds methods registration to be able to match id to string, see: https://github.com/utopia-rise/godot-jvm/pull/27