### PR TITLE
Fix class name registration when no package provided

### DIFF
--- a/src/main/kotlin/godot/entrygenerator/generator/clazz/JvmClassRegistrationGenerator.kt
+++ b/src/main/kotlin/godot/entrygenerator/generator/clazz/JvmClassRegistrationGenerator.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 class JvmClassRegistrationGenerator : ClassRegistrationGenerator() {
 
     override fun provideRegisterClassControlFlow(classWithMembers: ClassWithMembers, classRegistryControlFlow: FunSpec.Builder, className: ClassName, superClass: String, godotBaseClass: String, isTool: Boolean): FunSpec.Builder {
-        val classNameAsString = getClassNameAsString(classWithMembers.classDescriptor)
+        val classNameAsString = getClassNameAsString(classWithMembers.classDescriptor).removePrefix("_")
         EntryGenerator.registeredClassNames.add(classWithMembers.classDescriptor.fqNameSafe.asString() to classNameAsString)
         val classResPath = requireNotNull(EntryGenerator.fqNamesToRePath[classWithMembers.classDescriptor.fqNameSafe.asString()]) {
             "No resPath found for class ${classWithMembers.classDescriptor.fqNameSafe.asString()}"


### PR DESCRIPTION
This fixes the class name registration if the class is not in a package.

Previously they would be registered with a leading `_`. The leading `_` is now omitted.