### PR TITLE
Require constructors to be registered explicitly 

### DIFF
--- a/src/main/kotlin/godot/entrygenerator/EntryGenerator.kt
+++ b/src/main/kotlin/godot/entrygenerator/EntryGenerator.kt
@@ -160,8 +160,10 @@ object EntryGenerator {
             .filterNotNull()
             .filter { classFqName -> !classesFqNamesInCurrentCompilationRound.contains(classFqName) }
             .forEach { classFqName ->
-                val packagePath = classFqName.substringBeforeLast(".")
                 val classNameAsString = classFqName.substringAfterLast(".")
+                val packagePath = if (classNameAsString != classFqName) {
+                    classFqName.substringBeforeLast(".")
+                } else ""
                 mainEntryRegistryControlFlow.addStatement(
                     "%T().register(registry)",
                     ClassName("godot.$packagePath", "${classNameAsString}Registrar")

--- a/src/main/kotlin/godot/entrygenerator/model/Annotations.kt
+++ b/src/main/kotlin/godot/entrygenerator/model/Annotations.kt
@@ -2,6 +2,7 @@ package godot.entrygenerator.model
 
 const val GODOT_BASE_TYPE_ANNOTATION = "godot.annotation.GodotBaseType"
 const val REGISTER_CLASS_ANNOTATION = "godot.annotation.RegisterClass"
+const val REGISTER_CONSTRUCTOR_ANNOTATION = "godot.annotation.RegisterConstructor"
 const val REGISTER_FUNCTION_ANNOTATION = "godot.annotation.RegisterFunction"
 const val REGISTER_PROPERTY_ANNOTATION = "godot.annotation.RegisterProperty"
 const val REGISTER_SIGNAL_ANNOTATION = "godot.annotation.RegisterSignal"


### PR DESCRIPTION
This adds the requirement of registering constructors explicitly.
It also adds a check that a default constructor is present.
Default constructors are registered in any case, regardless of whether there is a `RegisterConstructor` anotation or not

It accompanies PR https://github.com/utopia-rise/godot-jvm/pull/80