### PR TITLE
bugfix/register right nullable class name

### DIFF
--- a/src/main/kotlin/godot/entrygenerator/generator/property/JvmPropertyRegistrationGenerator.kt
+++ b/src/main/kotlin/godot/entrygenerator/generator/property/JvmPropertyRegistrationGenerator.kt
@@ -83,7 +83,10 @@ class JvmPropertyRegistrationGenerator : PropertyRegistrationGenerator() {
                 registeredProperty.propertyDescriptor.type.toReturnKtVariantType(),
                 typeFqNameWithNullability,
                 PropertyTypeHintProvider.provide(registeredProperty.propertyDescriptor, EntryGenerationType.JVM),
-                PropertyHintStringGeneratorProvider.provide(registeredProperty.propertyDescriptor, bindingContext, EntryGenerationType.JVM).getHintString(),
+                PropertyHintStringGeneratorProvider
+                    .provide(registeredProperty.propertyDescriptor, bindingContext, EntryGenerationType.JVM)
+                    .getHintString()
+                    .replace("?", ""),
                 getRpcModeEnum(registeredProperty.propertyDescriptor)
             )
     }


### PR DESCRIPTION
This removes `?` to property hint string to avoid editor error warn